### PR TITLE
post: File, Dispatch, Finish

### DIFF
--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -90,3 +90,7 @@ The easiest solution for this would be to include the issue ID in the name of th
 Another thing that made this approach a bit painful was GitHub itself.
 I have an open terminal window with Claude Code and another window with the GitHub website.
 The GitHub website is very slow, so after verifying for some time that this is actually the process I want to follow, I found GitHub TUI tools to keep everything in one place and, importantly, fast.
+
+The way we build software is still being figured out, and this pipeline is just the shape that works for me right now.
+What I am fairly sure about is the direction: less manual coding, less micromanagement of the agent, and more time spent deciding what should be built rather than typing it out.
+File, dispatch, finish is simple enough that I can keep using it while everything around it keeps changing, and simple enough that you can take it and bend it to your own stack.

--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -4,12 +4,12 @@ date: 2026-06-13T00:00:00Z
 slug: "file-dispatch-finish"
 disqus_identifier: 2026-06-13
 author: martin
-summary: ""
+summary: "My approach to coding after graduating from university has not changed much up until early 2024, when I seriously started integrating AI in my daily workflows, but it seems that the most significant changes are still yet to come. At first, when experimenting with GitHub Copilot, I used it only for basic autocomplete of code in the closest scope. Then in 2025, I moved to Cursor which offered much better autocomplete capabilities. It worked throughout the whole file and multiple files as well. I could move faster and with very surgical precision. I tried to use the chat interface as well, but its capabilities were quite limited. It was useful mainly for debugging of known problematic parts of code, or for writing small-scope functions, and the experience was basically on-par with just using the free version of ChatGPT. All this time, the approaches of software engineers were more or less the same, because the tools were designed with a very specific use in mind."
 comments: true
 ---
 
 My approach to coding after graduating from university has not changed much up until early 2024, when I seriously started integrating AI in my daily workflows, but it seems that the most significant changes are still yet to come.
-At first, when experimenting with Github Copilot, I used it only for basic autocomplete of code in the closest scope.
+At first, when experimenting with GitHub Copilot, I used it only for basic autocomplete of code in the closest scope.
 Then in 2025, I moved to Cursor which offered much better autocomplete capabilities. It worked throughout the whole file and multiple files as well.
 I could move faster and with very surgical precision.
 I tried to use the chat interface as well, but its capabilities were quite limited.
@@ -28,6 +28,8 @@ The only requirements are GitHub (issues, PR, CI/CD), because I already have all
 The approach is defined as an abstract pipeline with three distinct consecutive steps: 1) File, 2) Dispatch and 3) Finish.
 The pipeline has to be executed in order, but there can be an unlimited number of pipelines running at the same time.
 The steps can be triggered by different actors from different places.
+
+<img src="/img/blog/file-dispatch-finish/pipeline.svg" width="100%">
 
 ## File
 
@@ -80,7 +82,7 @@ I have been using this system across multiple projects for more than two months,
 It allows me to work on many things at the same time, and even on multiple repositories without having too hard a time with context switching.
 I am very happy with having the issue to PR trail because it contains all the information that can get me, the AI, or other collaborators up to speed.
 There is, however, one thing that is a little bit bothersome and that is the dependency on the issue ID.
-It does not matter much in the first and second step, but at the third step I am looking at PR which has its own ID, and I have to make sure I find the right issue ID for the specific PR.
+It does not matter much in the first and second step, but at the third step I am looking at a PR which has its own ID, and I have to make sure I find the right issue ID for the specific PR.
 The easiest solution for this would be to include the issue ID in the name of the PR.
 Another thing that made this approach a bit painful was GitHub itself.
 I have an open terminal window with Claude Code and another window with the GitHub website.

--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -9,7 +9,6 @@ comments: true
 ---
 
 My approach to coding after graduating from university has not changed much up until early 2024, when I seriously started integrating AI in my daily workflows, but it seems that the most significant changes are still yet to come.
-The way we build software is being reshaped and I think we have not settled on any concrete approach yet, and who knows we might just end up with many more different approaches than we have known until now.
 At first, when experimenting with Github Copilot, I used it only for basic autocomplete of code in the closest scope.
 Then in 2025, I moved to Cursor which offered much better autocomplete capabilities. It worked throughout the whole file and multiple files as well.
 I could move faster and with very surgical precision.
@@ -19,10 +18,6 @@ All this time, the approaches of software engineers were more or less the same, 
 
 It all changed when Claude Opus started showing promising results in late 2025.
 Suddenly, the previously awkward chat interface became the way we express our needs and requirements when building systems.
-It might seem that chat interfaces had already been well known at that point, because everybody had experience with them in any of the freely available AI chats.
-However, unlike small-scope tab completion, or chat regarding specific small parts of code, the chat interface connected with very capable AI has changed the game.
-Suddenly, anybody with access to AI was able to build cool-looking demos, pretend to work while off-loading everything mindlessly on AI without any understanding, and accept all the work without review scrutiny.
-Developers became divided on whether the AI is good enough to take their jobs, while the AI models kept improving and breaking new records.
 Now, the AI is not just a chat interface, it is markdown documents describing how to behave, skills that can be readily loaded, memories of past conversations and many others.
 The software development work has become more about how to control the AI in order to get what you want, yet I still see people not taking advantage of it, and producing subpar work.
 It takes a lot of energy to stay up to date with new developments and approaches, but most importantly, there is now a nearly infinite number of ways to do the same thing.

--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -32,6 +32,7 @@ It shouldn't require me to build complex pipelines, install new software, or int
 The only requirements are GitHub (issues, PR, CI/CD), because I already have all the code there, and Claude (coding, orchestration, memory), because that is my current AI of choice, but any other AI would work the same way.
 The approach is defined as an abstract pipeline with three distinct consecutive steps: 1) File, 2) Dispatch and 3) Finish.
 The pipeline has to be executed in order, but there can be an unlimited number of pipelines running at the same time.
+The steps can be triggered by different actors from different places.
 
 ## File
 

--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -11,7 +11,7 @@ comments: true
 My approach to coding after graduating from university has not changed much up until early 2024, when I seriously started integrating AI in my daily workflows, but it seems that the most significant changes are still yet to come.
 The way we build software is being reshaped and I think we have not settled on any concrete approach yet, and who knows we might just end up with many more different approaches than we have known until now.
 At first, when experimenting with Github Copilot, I used it only for basic autocomplete of code in the closest scope.
-Then in 2025, I moved to Cursor which offered much better autocomplete capabilities; it worked throughout the whole file and multiple files as well.
+Then in 2025, I moved to Cursor which offered much better autocomplete capabilities. It worked throughout the whole file and multiple files as well.
 I could move faster and with very surgical precision.
 I tried to use the chat interface as well, but its capabilities were quite limited.
 It was useful mainly for debugging of known problematic parts of code, or for writing small-scope functions, and the experience was basically on-par with just using the free version of ChatGPT.
@@ -63,7 +63,7 @@ The agent then starts working on the issue following the dispatch issue skill (p
 7. Notify about completion
 
 The review agent finds at least one issue in most of the PRs that the original agent created, unless the PR is very small.
-The limit of five review rounds was set just as a guess; it has never gone over four rounds of reviews.
+The limit of five review rounds was set just as a guess. It has never gone over four rounds of reviews.
 
 
 ## Finish

--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -8,69 +8,84 @@ summary: ""
 comments: true
 ---
 
-My approach to coding after graduating university has not changed much up until early 2024, when I have seriously started integrating AI in my daily workflows, but it seems that the most significant changes are still yet to come.
-The way how we build software is being reshaped and I think we have not settled on any concrete approach yet, and who knows we might just end up with many more different approaches than we have known until now.
-At first, when experimenting with Github Copilot, I have used it only for basic autocomplete of code in the closest scope.
-Then in 2025, I moved to Cursor which offered much better autocomplete capabilities, it worked throughout the whole file and multiple files as well.
+My approach to coding after graduating from university has not changed much up until early 2024, when I seriously started integrating AI in my daily workflows, but it seems that the most significant changes are still yet to come.
+The way we build software is being reshaped and I think we have not settled on any concrete approach yet, and who knows we might just end up with many more different approaches than we have known until now.
+At first, when experimenting with Github Copilot, I used it only for basic autocomplete of code in the closest scope.
+Then in 2025, I moved to Cursor which offered much better autocomplete capabilities; it worked throughout the whole file and multiple files as well.
 I could move faster and with very surgical precision.
-I have tried to use the chat interface as well, but its capabilities were quite limited.
-It was useful mainly for debugging of known problematic parts of code, or for writing small-scope functions, and the experience was basically on-par with just using free version of ChatGPT.
-All this time, the approaches of software engineers were more or less same, because the tools were designed with a very specific use in mind.
+I tried to use the chat interface as well, but its capabilities were quite limited.
+It was useful mainly for debugging of known problematic parts of code, or for writing small-scope functions, and the experience was basically on-par with just using the free version of ChatGPT.
+All this time, the approaches of software engineers were more or less the same, because the tools were designed with a very specific use in mind.
 
-It all changed when Claude Opus has started showing promising results in late 2025.
-Suddenly, the previously awkward chat interface became the way how we express our needs and requirements when building systems.
-It might seem that chat interfaces has already been well known at that point, because everybody had experience with it in any of freely available AI chats.
+It all changed when Claude Opus started showing promising results in late 2025.
+Suddenly, the previously awkward chat interface became the way we express our needs and requirements when building systems.
+It might seem that chat interfaces had already been well known at that point, because everybody had experience with them in any of the freely available AI chats.
 However, unlike small-scope tab completion, or chat regarding specific small parts of code, the chat interface connected with very capable AI has changed the game.
-Suddenly, anybody with access to AI was able to build cool looking demos, pretend to work while off-loading everything mindlessly on AI without any understanding, and accepting all the work without review scrutiny.
+Suddenly, anybody with access to AI was able to build cool-looking demos, pretend to work while off-loading everything mindlessly on AI without any understanding, and accept all the work without review scrutiny.
 Developers became divided on whether the AI is good enough to take their jobs, while the AI models kept improving and breaking new records.
-Now, the AI is not just chat interface, it is markdown documents describing how to behave, skills that can be readily loaded, memories of past conversation and many others.
-The softward development work has become more of how to control the AI in order to get what you want, yet I still see people not taking advantage of it, and producing subpar work.
-It takes a lot of energy to stay up to date with new developments and approaches, but most importantly, there are now nearly infinite number of ways how to do the same thing.
+Now, the AI is not just a chat interface, it is markdown documents describing how to behave, skills that can be readily loaded, memories of past conversations and many others.
+The software development work has become more about how to control the AI in order to get what you want, yet I still see people not taking advantage of it, and producing subpar work.
+It takes a lot of energy to stay up to date with new developments and approaches, but most importantly, there is now a nearly infinite number of ways to do the same thing.
 
-When I thought how take advantage of this rapidly changing environment, I knew that my new approach has to be very simple.
-It shouldn't require me to build complex pipelines, install new software, or integrate something because of some feature that is already supported by required stack.
-The only requirements are Github (issues, PR, CI/CD), because I already have all the code there, and Claude (coding, orchestration, memory), because that is my current AI of choice, but any other AI would work the same way.
+When I thought about how to take advantage of this rapidly changing environment, I knew that my new approach had to be very simple.
+It shouldn't require me to build complex pipelines, install new software, or integrate something because of some feature that is already supported by the required stack.
+The only requirements are GitHub (issues, PR, CI/CD), because I already have all the code there, and Claude (coding, orchestration, memory), because that is my current AI of choice, but any other AI would work the same way.
 The approach is defined as an abstract pipeline with three distinct consecutive steps: 1) File, 2) Dispatch and 3) Finish.
-The pipeline has to be executed in order, but there can be unlimited number of pipelines running at the same time.
+The pipeline has to be executed in order, but there can be an unlimited number of pipelines running at the same time.
 
 ## File
 
 The first step in the pipeline is to record what we want to do or what we should do.
-When there is feature, we want to develop, or when there is a bug we want to fix, we can file an issue through Claude code.
-Claude code comes with `/new-issue` skill which allows us to generate and post issue to GitHub.
-Claude code has access to the context of the repository on which we run the skill, therefore it can provide many important details even before we start working on the issue.
+When there is a feature we want to develop, or when there is a bug we want to fix, we can file an issue through Claude Code.
+Claude Code comes with a `/new-issue` skill which allows us to generate and post an issue to GitHub.
+Claude Code has access to the context of the repository on which we run the skill, so it can provide many important details even before we start working on the issue.
 The issue can be filed by any other system that has write rights to the GitHub repository.
-We can file as many issues as we want, or just one and move on to the next stage, but important thing is that it depends on situation and we are not limited.
+We can file as many issues as we want, or just one and move on to the next stage, but the important thing is that it depends on the situation and we are not limited.
 
 
 ## Dispatch
 
 The dispatch step is when the AI actually starts working on the problem.
-Similarly to the previous step, there are multiple ways how we can trigger it: manually or automatically by system that has access to GitHub to read issue, write code, and open PR.
-When working on new features or bug fixes, I trigger this step manually from within a new `claude agents` session using custom skill `/dispatch-issue` which requires me to specify the issue ID (e.g. `/dispatch-issue 593`).
+Similarly to the previous step, there are multiple ways we can trigger it: manually or automatically by a system that has access to GitHub to read the issue, write code, and open a PR.
+When working on new features or bug fixes, I trigger this step manually from within a new `claude agents` session using a custom skill `/dispatch-issue` which requires me to specify the issue ID (e.g. `/dispatch-issue 593`).
 Sometimes, I might want to add a little more context, but most of the time, I just specify the ID.
-Agent then starts working on the issue following the dispatch issue skill (paraphrased below):
+The agent then starts working on the issue following the dispatch issue skill (paraphrased below):
 
-1. Attach WIP prefix to the issue that was dispatch
+1. Attach WIP prefix to the issue that was dispatched
 2. Your goal is to solve the problem explained in the issue
-3. Before coding anything, ask for confirmation if there are multiple way of achieving the goal
-4. Split the work in to the steps that are separated by commits
+3. Before coding anything, ask for confirmation if there are multiple ways of achieving the goal
+4. Split the work into the steps that are separated by commits
 5. Open PR and link it to the issue
-6. (repeat up to 5 times)
-  * 6a. Launch review agent on your PR
-  * 6b. Fix his findings directly in PR if they are related
-  * 6c. Files new issues based on unresolved findings
+6. Repeat the following up to 5 times:
+   - Launch review agent on your PR
+   - Fix its findings directly in the PR if they are related
+   - File new issues based on unresolved findings
 7. Notify about completion
 
-The review agent finds at least 1 issue in most of the PRs that the original agent created, unless the PR is very small.
-The limit of five review rounds was set just as guess, it has never went over 4 rounds of reviews.
+The review agent finds at least one issue in most of the PRs that the original agent created, unless the PR is very small.
+The limit of five review rounds was set just as a guess; it has never gone over four rounds of reviews.
 
 
 ## Finish
 
-The last step exist mainly to make sure that the generated code solves the problem we wanted to tackle, and to help AI to learn from this completed issue.
-It is less complex, and composed of three substeps:
+Currently, the last step is always triggered by me, and never through automated processes.
+It is mainly to make sure that the generated code solves the problem we wanted to tackle, to help the AI learn from this completed issue, and maybe surprisingly to help me stay up to date with everything that is going on because it can get challenging.
+The step is triggered by the `/finish-issue` skill which requires me to specify the issue ID, which is tied to the PR (e.g. `/finish-issue 593`).
+It is composed of three substeps:
 
 1. Merge the PR if all checks passed
 2. Remove the WIP prefix from the related issue
-3. Update your memory about the project based on this work
+3. Update AI memory about the project based on this work
+
+
+## Conclusion
+
+I have been using this system across multiple projects for more than two months, and so far it works reasonably well.
+It allows me to work on many things at the same time, and even on multiple repositories without having too hard a time with context switching.
+I am very happy with having the issue to PR trail because it contains all the information that can get me, the AI, or other collaborators up to speed.
+There is, however, one thing that is a little bit bothersome and that is the dependency on the issue ID.
+It does not matter much in the first and second step, but at the third step I am looking at PR which has its own ID, and I have to make sure I find the right issue ID for the specific PR.
+The easiest solution for this would be to include the issue ID in the name of the PR.
+Another thing that made this approach a bit painful was GitHub itself.
+I have an open terminal window with Claude Code and another window with the GitHub website.
+The GitHub website is very slow, so after verifying for some time that this is actually the process I want to follow, I found GitHub TUI tools to keep everything in one place and, importantly, fast.

--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -1,0 +1,76 @@
+---
+title: "File, Dispatch, Finish"
+date: 2026-06-13T00:00:00Z
+slug: "file-dispatch-finish"
+disqus_identifier: 2026-06-13
+author: martin
+summary: ""
+comments: true
+---
+
+My approach to coding after graduating university has not changed much up until early 2024, when I have seriously started integrating AI in my daily workflows, but it seems that the most significant changes are still yet to come.
+The way how we build software is being reshaped and I think we have not settled on any concrete approach yet, and who knows we might just end up with many more different approaches than we have known until now.
+At first, when experimenting with Github Copilot, I have used it only for basic autocomplete of code in the closest scope.
+Then in 2025, I moved to Cursor which offered much better autocomplete capabilities, it worked throughout the whole file and multiple files as well.
+I could move faster and with very surgical precision.
+I have tried to use the chat interface as well, but its capabilities were quite limited.
+It was useful mainly for debugging of known problematic parts of code, or for writing small-scope functions, and the experience was basically on-par with just using free version of ChatGPT.
+All this time, the approaches of software engineers were more or less same, because the tools were designed with a very specific use in mind.
+
+It all changed when Claude Opus has started showing promising results in late 2025.
+Suddenly, the previously awkward chat interface became the way how we express our needs and requirements when building systems.
+It might seem that chat interfaces has already been well known at that point, because everybody had experience with it in any of freely available AI chats.
+However, unlike small-scope tab completion, or chat regarding specific small parts of code, the chat interface connected with very capable AI has changed the game.
+Suddenly, anybody with access to AI was able to build cool looking demos, pretend to work while off-loading everything mindlessly on AI without any understanding, and accepting all the work without review scrutiny.
+Developers became divided on whether the AI is good enough to take their jobs, while the AI models kept improving and breaking new records.
+Now, the AI is not just chat interface, it is markdown documents describing how to behave, skills that can be readily loaded, memories of past conversation and many others.
+The softward development work has become more of how to control the AI in order to get what you want, yet I still see people not taking advantage of it, and producing subpar work.
+It takes a lot of energy to stay up to date with new developments and approaches, but most importantly, there are now nearly infinite number of ways how to do the same thing.
+
+When I thought how take advantage of this rapidly changing environment, I knew that my new approach has to be very simple.
+It shouldn't require me to build complex pipelines, install new software, or integrate something because of some feature that is already supported by required stack.
+The only requirements are Github (issues, PR, CI/CD), because I already have all the code there, and Claude (coding, orchestration, memory), because that is my current AI of choice, but any other AI would work the same way.
+The approach is defined as an abstract pipeline with three distinct consecutive steps: 1) File, 2) Dispatch and 3) Finish.
+The pipeline has to be executed in order, but there can be unlimited number of pipelines running at the same time.
+
+## File
+
+The first step in the pipeline is to record what we want to do or what we should do.
+When there is feature, we want to develop, or when there is a bug we want to fix, we can file an issue through Claude code.
+Claude code comes with `/new-issue` skill which allows us to generate and post issue to GitHub.
+Claude code has access to the context of the repository on which we run the skill, therefore it can provide many important details even before we start working on the issue.
+The issue can be filed by any other system that has write rights to the GitHub repository.
+We can file as many issues as we want, or just one and move on to the next stage, but important thing is that it depends on situation and we are not limited.
+
+
+## Dispatch
+
+The dispatch step is when the AI actually starts working on the problem.
+Similarly to the previous step, there are multiple ways how we can trigger it: manually or automatically by system that has access to GitHub to read issue, write code, and open PR.
+When working on new features or bug fixes, I trigger this step manually from within a new `claude agents` session using custom skill `/dispatch-issue` which requires me to specify the issue ID (e.g. `/dispatch-issue 593`).
+Sometimes, I might want to add a little more context, but most of the time, I just specify the ID.
+Agent then starts working on the issue following the dispatch issue skill (paraphrased below):
+
+1. Attach WIP prefix to the issue that was dispatch
+2. Your goal is to solve the problem explained in the issue
+3. Before coding anything, ask for confirmation if there are multiple way of achieving the goal
+4. Split the work in to the steps that are separated by commits
+5. Open PR and link it to the issue
+6. (repeat up to 5 times)
+  * 6a. Launch review agent on your PR
+  * 6b. Fix his findings directly in PR if they are related
+  * 6c. Files new issues based on unresolved findings
+7. Notify about completion
+
+The review agent finds at least 1 issue in most of the PRs that the original agent created, unless the PR is very small.
+The limit of five review rounds was set just as guess, it has never went over 4 rounds of reviews.
+
+
+## Finish
+
+The last step exist mainly to make sure that the generated code solves the problem we wanted to tackle, and to help AI to learn from this completed issue.
+It is less complex, and composed of three substeps:
+
+1. Merge the PR if all checks passed
+2. Remove the WIP prefix from the related issue
+3. Update your memory about the project based on this work

--- a/content/posts/2026-06-13-file-dispatch-finish.md
+++ b/content/posts/2026-06-13-file-dispatch-finish.md
@@ -19,7 +19,7 @@ All this time, the approaches of software engineers were more or less the same, 
 It all changed when Claude Opus started showing promising results in late 2025.
 Suddenly, the previously awkward chat interface became the way we express our needs and requirements when building systems.
 Now, the AI is not just a chat interface, it is markdown documents describing how to behave, skills that can be readily loaded, memories of past conversations and many others.
-The software development work has become more about how to control the AI in order to get what you want, yet I still see people not taking advantage of it, and producing subpar work.
+The software development work has become more about how to control the AI in order to get what you want, yet I still see people not taking advantage of it.
 It takes a lot of energy to stay up to date with new developments and approaches, but most importantly, there is now a nearly infinite number of ways to do the same thing.
 
 When I thought about how to take advantage of this rapidly changing environment, I knew that my new approach had to be very simple.
@@ -28,8 +28,9 @@ The only requirements are GitHub (issues, PR, CI/CD), because I already have all
 The approach is defined as an abstract pipeline with three distinct consecutive steps: 1) File, 2) Dispatch and 3) Finish.
 The pipeline has to be executed in order, but there can be an unlimited number of pipelines running at the same time.
 The steps can be triggered by different actors from different places.
+This lets us parallelize the work of many agents while still being able to understand what is being done.
 
-<img src="/img/blog/file-dispatch-finish/pipeline.svg" width="100%">
+<img src="/img/blog/file-dispatch-finish/pipeline.svg" width="100%" alt="File, Dispatch, Finish pipeline">
 
 ## File
 
@@ -47,18 +48,18 @@ The dispatch step is when the AI actually starts working on the problem.
 Similarly to the previous step, there are multiple ways we can trigger it: manually or automatically by a system that has access to GitHub to read the issue, write code, and open a PR.
 When working on new features or bug fixes, I trigger this step manually from within a new `claude agents` session using a custom skill `/dispatch-issue` which requires me to specify the issue ID (e.g. `/dispatch-issue 593`).
 Sometimes, I might want to add a little more context, but most of the time, I just specify the ID.
-The agent then starts working on the issue following the dispatch issue skill (paraphrased below):
+Each dispatched agent works in its own separate git worktree, so multiple issues can be worked on at the same time without interfering with each other.
+The agent then starts working on the issue following the `/dispatch-issue` skill, whose goal is to solve the problem explained in the issue (paraphrased below):
 
 1. Attach WIP prefix to the issue that was dispatched
-2. Your goal is to solve the problem explained in the issue
-3. Before coding anything, ask for confirmation if there are multiple ways of achieving the goal
-4. Split the work into the steps that are separated by commits
-5. Open PR and link it to the issue
-6. Repeat the following up to 5 times:
+2. Before coding anything, ask for confirmation if there are multiple ways of achieving the goal
+3. Split the work into the steps that are separated by commits
+4. Open PR and link it to the issue
+5. Repeat the following up to 5 times:
    - Launch review agent on your PR
    - Fix its findings directly in the PR if they are related
    - File new issues based on unresolved findings
-7. Notify about completion
+6. Notify about completion
 
 The review agent finds at least one issue in most of the PRs that the original agent created, unless the PR is very small.
 The limit of five review rounds was set just as a guess. It has never gone over four rounds of reviews.
@@ -69,7 +70,7 @@ The limit of five review rounds was set just as a guess. It has never gone over 
 Currently, the last step is always triggered by me, and never through automated processes.
 It is mainly to make sure that the generated code solves the problem we wanted to tackle, to help the AI learn from this completed issue, and maybe surprisingly to help me stay up to date with everything that is going on because it can get challenging.
 The step is triggered by the `/finish-issue` skill which requires me to specify the issue ID, which is tied to the PR (e.g. `/finish-issue 593`).
-It is composed of three substeps:
+It is composed of three substeps, but before any of them I verify by hand that the change actually solves the problem described in the issue:
 
 1. Merge the PR if all checks passed
 2. Remove the WIP prefix from the related issue
@@ -78,15 +79,14 @@ It is composed of three substeps:
 
 ## Conclusion
 
-I have been using this system across multiple projects for more than two months, and so far it works reasonably well.
-It allows me to work on many things at the same time, and even on multiple repositories without having too hard a time with context switching.
+I have been using this system across multiple projects for more than two months, and the main payoff is exactly what I was after: I can confidently work on many things at the same time, even across multiple repositories, without having too hard a time with context switching.
 I am very happy with having the issue to PR trail because it contains all the information that can get me, the AI, or other collaborators up to speed.
 There is, however, one thing that is a little bit bothersome and that is the dependency on the issue ID.
 It does not matter much in the first and second step, but at the third step I am looking at a PR which has its own ID, and I have to make sure I find the right issue ID for the specific PR.
 The easiest solution for this would be to include the issue ID in the name of the PR.
 Another thing that made this approach a bit painful was GitHub itself.
 I have an open terminal window with Claude Code and another window with the GitHub website.
-The GitHub website is very slow, so after verifying for some time that this is actually the process I want to follow, I found GitHub TUI tools to keep everything in one place and, importantly, fast.
+The GitHub website is very slow, so I have been building my own faster way to keep everything in one place. I will be sharing more information about it soon.
 
 The way we build software is still being figured out, and this pipeline is just the shape that works for me right now.
 What I am fairly sure about is the direction: less manual coding, less micromanagement of the agent, and more time spent deciding what should be built rather than typing it out.

--- a/static/css/grayscale.css
+++ b/static/css/grayscale.css
@@ -685,7 +685,7 @@ section#main-content div#post span#name, span.post_name {
   font-size: 1em;
 }
 
-ol li {
+ol > li {
     font-size: 1.1em;
     line-height: 1.8em;
 }

--- a/static/img/blog/file-dispatch-finish/pipeline.svg
+++ b/static/img/blog/file-dispatch-finish/pipeline.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#666"/>
+    </marker>
+  </defs>
+
+  <!-- boxes -->
+  <g>
+    <rect x="20"  y="80" width="200" height="80" rx="8" fill="#f4f4f4" stroke="#888" stroke-width="2"/>
+    <rect x="290" y="80" width="200" height="80" rx="8" fill="#f4f4f4" stroke="#888" stroke-width="2"/>
+    <rect x="560" y="80" width="200" height="80" rx="8" fill="#f4f4f4" stroke="#888" stroke-width="2"/>
+  </g>
+
+  <!-- step numbers -->
+  <g fill="#999" font-size="13" font-weight="700">
+    <text x="34" y="100">1</text>
+    <text x="304" y="100">2</text>
+    <text x="574" y="100">3</text>
+  </g>
+
+  <!-- titles -->
+  <g fill="#222" font-size="24" font-weight="700" text-anchor="middle">
+    <text x="120" y="122">File</text>
+    <text x="390" y="122">Dispatch</text>
+    <text x="660" y="122">Finish</text>
+  </g>
+
+  <!-- skill labels -->
+  <g fill="#555" font-size="13" font-family="'SFMono-Regular', Menlo, Consolas, monospace" text-anchor="middle">
+    <text x="120" y="146">/new-issue</text>
+    <text x="390" y="146">/dispatch-issue</text>
+    <text x="660" y="146">/finish-issue</text>
+  </g>
+
+  <!-- captions -->
+  <g fill="#777" font-size="12.5" text-anchor="middle">
+    <text x="120" y="190">record the task</text>
+    <text x="120" y="207">as a GitHub issue</text>
+    <text x="390" y="190">agent writes code,</text>
+    <text x="390" y="207">opens PR, self-reviews</text>
+    <text x="660" y="190">verify, merge,</text>
+    <text x="660" y="207">update memory</text>
+  </g>
+
+  <!-- arrows between stages -->
+  <line x1="224" y1="120" x2="286" y2="120" stroke="#666" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="494" y1="120" x2="556" y2="120" stroke="#666" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- review loop over Dispatch -->
+  <path d="M340 80 C340 40, 440 40, 440 78" fill="none" stroke="#666" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="390" y="38" fill="#777" font-size="12.5" text-anchor="middle">review loop (up to 5x)</text>
+</svg>


### PR DESCRIPTION
New blog post describing the File → Dispatch → Finish pipeline (GitHub + Claude Code) for running agent work in parallel.

## Summary
- New post `content/posts/2026-06-13-file-dispatch-finish.md`: intro/personal arc, the three-step pipeline (`/new-issue` → `/dispatch-issue` → `/finish-issue`), and a conclusion covering the payoff (confident parallelism) and open frictions.
- Added pipeline diagram `static/img/blog/file-dispatch-finish/pipeline.svg` (grayscale SVG, embedded after the intro).
- CSS fix: scoped `ol li` → `ol > li` in `static/css/grayscale.css` so nested list items no longer compound `font-size` (1.1em → 1.21em). Affects ordered lists site-wide.

## Testing
- Diagram rendered locally via qlmanage to verify layout.
- No automated tests in repo; not run.