### PR TITLE
post: external-link posts for two Hyperconnect articles

### DIFF
--- a/content/posts/2018-06-26-lpirc-2018.md
+++ b/content/posts/2018-06-26-lpirc-2018.md
@@ -1,0 +1,9 @@
+---
+title:  "Low Power Image Recognition Challenge 2018"
+date: 2018-06-26T00:00:00Z
+slug: "lpirc-2018"
+author: martin
+authors: "Beomjun Shin, Seungwoo Choi, Hyeongmin Byun, Hyungsuk Yoon, Seokjun Seo, Martin Kersner"
+external_url: "https://hyperconnect.github.io/2018/06/26/lpirc-2018.html"
+summary: "Last week (June 18-22, 2018), two members of Machine Learning team from Hyperconnect visited <a href=\"http://cvpr2018.thecvf.com/\" target=\"_blank\" rel=\"noopener\">Computer Vision and Pattern Recognition (CVPR)</a> conference in Salt Lake City, Utah. Prior to coming to CVPR, Machine Learning team engaged in one of the challenges called <a href=\"https://rebootingcomputing.ieee.org/lpirc\" target=\"_blank\" rel=\"noopener\">Low Power Image Recognition Challenge (LPIRC)</a>, jointly organized by <a href=\"https://www.purdue.edu/\" target=\"_blank\" rel=\"noopener\">Purdue University</a> and Google."
+---

--- a/content/posts/2018-07-06-fast-portrait-segmentation-tflite.md
+++ b/content/posts/2018-07-06-fast-portrait-segmentation-tflite.md
@@ -1,0 +1,9 @@
+---
+title:  "Tips for building fast portrait segmentation network with TensorFlow Lite"
+date: 2018-07-06T00:00:00Z
+slug: "tips-for-building-fast-portrait-segmentation-network-with-tensorflow-lite"
+author: martin
+authors: "Beomjun Shin, Seungwoo Choi, Hyeongmin Byun, Hyungsuk Yoon, Seokjun Seo, Martin Kersner"
+external_url: "https://hyperconnect.github.io/2018/07/06/tips-for-building-fast-portrait-segmentation-network-with-tensorflow-lite.html"
+summary: "Deep learning has led to a series of breakthroughs in many areas. However, successful deep learning models often require significant amounts of computational resources, memory and power. Deploying efficient deep learning models on mobile devices became the main technological challenge for many mobile tech companies. Hyperconnect developed a mobile app named <a href=\"http://azarlive.com/\" target=\"_blank\" rel=\"noopener\">Azar</a> which has a large fan base all over the world. Recently, Machine Learning Team has been focusing on developing mobile deep learning technologies which can boost user experience in Azar app. Below, you can see a demo video of our image segmentation technology (HyperCut) running on <a href=\"https://www.sammobile.com/devices/galaxy-j7/specs/SM-J700F/\" target=\"_blank\" rel=\"noopener\">Samsung Galaxy J7</a>. Our benchmark target is a real-time (&gt;= 30 fps) inference on Galaxy J7 (Exynos 7580 CPU, 1.5 GHz) using only a single core."
+---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,11 +6,15 @@
         {{ range $posts.GroupByDate "2006 Jan" }}
           <div>
             {{ range .Pages }}
-              <h3 class="post_title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+              {{ $link := .RelPermalink }}
+              {{ $ext := "" }}
+              {{ with .Params.external_url }}{{ $link = . }}{{ $ext = "target=\"_blank\" rel=\"noopener\"" }}{{ end }}
+              <h3 class="post_title"><a href="{{ $link }}" {{ $ext | safeHTMLAttr }}>{{ .Title }}</a></h3>
               <span class="post_date">{{ .Date.Format "January 2, 2006" }}</span>
+              {{ with .Params.authors }}<span class="post_name">{{ . | safeHTML }}</span>{{ end }}
               <p>
                 {{ with .Params.summary }}{{ . | safeHTML }}{{ end }}
-                <br><a href="{{ .RelPermalink }}">Read more</a>
+                <br><a href="{{ $link }}" {{ $ext | safeHTMLAttr }}>Read more</a>
               </p>
             {{ end }}
           </div>


### PR DESCRIPTION
## Summary

Adds two 2018 blog posts that link out to Hyperconnect's tech blog instead of an internal page:

- **Low Power Image Recognition Challenge 2018** → hyperconnect.github.io/2018/06/26/lpirc-2018.html
- **Tips for building fast portrait segmentation network with TensorFlow Lite** → hyperconnect.github.io/2018/07/06/...

Mechanism: new `external_url` front-matter field. On the main page, the post title + "Read more" point to that URL (new tab, `rel=noopener`) when set; otherwise they use the internal permalink as before. Reusable for future external posts.

Each summary reproduces the source article's opening paragraph(s) with the original inline links preserved.

Also added an optional `authors` line (reusing the existing `post_name` style), rendered on the main page only for posts that set it. Both new posts list: Beomjun Shin, Seungwoo Choi, Hyeongmin Byun, Hyungsuk Yoon, Seokjun Seo, Martin Kersner. Existing posts are unchanged.

## Tests

- `hugo --minify` builds clean.
- Verified built `public/index.html`: both new posts link externally (new tab), summaries keep their links, authors line renders for these two posts only; all other posts keep internal links and show no authors.

## Known failures

None.